### PR TITLE
Remove the upper limit of the Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,11 @@ authors = [
 ]
 description = "Graph Atomic Cluster Expansion (GRACE)"
 readme = "README.md"
-requires-python = ">=3.9,<3.13" # Update if needed
+requires-python = ">=3.9" # Update if needed
 license = { text = "Academic Software License (ASL)" }
 classifiers = [
     "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     # for windows and macos


### PR DESCRIPTION
# Pull Request Template

First of all, thank you @yury-lysogorskiy and @AntBoc for your development!

## Description of Changes

In this short PR, I would like to suggest removing the upper limit of the Python version from `pyproject.toml`.

This is simply because of the inconvenience for latest Python environments.
For example, if we start a new project with e.g. conda, the default Python version is now 3.14.
Then, later if we would like to install `tensorpotential`, this cannot be done presently in the same environment created above.

Since `tensorpotential` itself is a pure Python package, it makes less sense to have an upper limit for the Python version.
For most practical cases, Python would preserve backward compatibility, and we can just test the code with the minimum supported Python version (`3.9` in the present `pyproject.toml`).
In case other packages like `tensorflow` need the upper limit, this will likely be specified on their side.

I hope what I wrote above is reasonable, but any feedbacks are appreciated for me to better understand the code.
If it's done, it would also be helpful for the community to have a minor update (may be `0.5.10`) so that it gets available in PyPI and conda-forge.

## Checklist

- [ ] Code is well-documented.
- [ ] All tests have been run and passed.
- [ ] Relevant documentation has been updated if necessary.

## License Agreement

By submitting this pull request, I agree that:
- The code submitted in this pull request will be distributed under the Academic Software License (free for academic non-commercial use, not free for commercial use), see [LICENSE.md](https://github.com/ICAMS/python-ace/blob/master/LICENSE.md) for more details.
- The copyright for the code, including the submitted code, remains with Ruhr University Bochum.  Ruhr University Bochum retains the right to transfer or modify the copyright.